### PR TITLE
Add the option of using add_field_info inside map

### DIFF
--- a/docs/user-guide/api/map.md
+++ b/docs/user-guide/api/map.md
@@ -1,7 +1,6 @@
-
 # Map
 
-Applies a function to all leaves in a pytree using `jax.tree_map`. If `filters` are given then the function will be applied only to the subset of leaves that match the filters.
+Applies a function to all leaves in a pytree using `jax.tree_map`. If `filters` are given then the function will be applied only to the subset of leaves that match the filters. Further, property of the field's kind type can be used within `map` by setting the `field_info` argument as True.
 
 For example, if we want to zero all batch stats we can do:
 
@@ -18,6 +17,15 @@ tree = MyTree(a=1, b=2)
 to.map(lambda _: 0, tree, BatchStat) # MyTree(a=1, b=0)
 ```
 
+We could also apply a custom function to those fields with the Parameter type
+
+```python
+def parameter_fn(field):
+    return f + 1
+
+to.map(parameter_fn, tree, Parameter, field_info = True)  # MyTree(a=2, b=2)
+
 `map` is equivalent to `filter -> tree_map -> merge` in sequence.
 
 If `inplace` is `True`, the input `obj` is mutated and returned. You can only update inplace if the input `obj` has a `__dict__` attribute, else a `TypeError` is raised.
+```

--- a/docs/user-guide/api/map.md
+++ b/docs/user-guide/api/map.md
@@ -24,8 +24,8 @@ def parameter_fn(field):
     return f + 1
 
 to.map(parameter_fn, tree, Parameter, field_info = True)  # MyTree(a=2, b=2)
+```
 
 `map` is equivalent to `filter -> tree_map -> merge` in sequence.
 
 If `inplace` is `True`, the input `obj` is mutated and returned. You can only update inplace if the input `obj` has a `__dict__` attribute, else a `TypeError` is raised.
-```


### PR DESCRIPTION
This PR addresses the comments made in #2 . An additional argument is created within `map` to allow for a `field_info` boolean flag to passed. When true, `jax.tree_map` is carried out under the `with add_field_info():` context manager. 

Tests have been added to test for correct function application on classes contain Trees with mixed kind types. 

A brief section has been added to the documentation to reflect the above changes.