### PR TITLE
Adds support for immutable Trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ data
 # rsync
 .git/
 tmp/
+
+# docs
+/docs/api

--- a/docs/api/Apply.md
+++ b/docs/api/Apply.md
@@ -1,6 +1,0 @@
-
-# treeo.Apply
-
-::: treeo.Apply
-    selection:
-        inherited_members: true

--- a/docs/api/ArrayLike.md
+++ b/docs/api/ArrayLike.md
@@ -1,6 +1,0 @@
-
-# treeo.ArrayLike
-
-::: treeo.ArrayLike
-    selection:
-        inherited_members: true

--- a/docs/api/Compact.md
+++ b/docs/api/Compact.md
@@ -1,6 +1,0 @@
-
-# treeo.Compact
-
-::: treeo.Compact
-    selection:
-        inherited_members: true

--- a/docs/api/Copy.md
+++ b/docs/api/Copy.md
@@ -1,6 +1,0 @@
-
-# treeo.Copy
-
-::: treeo.Copy
-    selection:
-        inherited_members: true

--- a/docs/api/Extensions.md
+++ b/docs/api/Extensions.md
@@ -1,6 +1,0 @@
-
-# treeo.Extensions
-
-::: treeo.Extensions
-    selection:
-        inherited_members: true

--- a/docs/api/FieldInfo.md
+++ b/docs/api/FieldInfo.md
@@ -1,6 +1,0 @@
-
-# treeo.FieldInfo
-
-::: treeo.FieldInfo
-    selection:
-        inherited_members: true

--- a/docs/api/FieldMetadata.md
+++ b/docs/api/FieldMetadata.md
@@ -1,6 +1,0 @@
-
-# treeo.FieldMetadata
-
-::: treeo.FieldMetadata
-    selection:
-        inherited_members: true

--- a/docs/api/Filter.md
+++ b/docs/api/Filter.md
@@ -1,6 +1,0 @@
-
-# treeo.Filter
-
-::: treeo.Filter
-    selection:
-        inherited_members: true

--- a/docs/api/FlattenMode.md
+++ b/docs/api/FlattenMode.md
@@ -1,6 +1,0 @@
-
-# treeo.FlattenMode
-
-::: treeo.FlattenMode
-    selection:
-        inherited_members: true

--- a/docs/api/Hashable.md
+++ b/docs/api/Hashable.md
@@ -1,6 +1,0 @@
-
-# treeo.Hashable
-
-::: treeo.Hashable
-    selection:
-        inherited_members: true

--- a/docs/api/KindMixin.md
+++ b/docs/api/KindMixin.md
@@ -1,6 +1,0 @@
-
-# treeo.KindMixin
-
-::: treeo.KindMixin
-    selection:
-        inherited_members: true

--- a/docs/api/MISSING.md
+++ b/docs/api/MISSING.md
@@ -1,6 +1,0 @@
-
-# treeo.MISSING
-
-::: treeo.MISSING
-    selection:
-        inherited_members: true

--- a/docs/api/Map.md
+++ b/docs/api/Map.md
@@ -1,6 +1,0 @@
-
-# treeo.Map
-
-::: treeo.Map
-    selection:
-        inherited_members: true

--- a/docs/api/Merge.md
+++ b/docs/api/Merge.md
@@ -1,6 +1,0 @@
-
-# treeo.Merge
-
-::: treeo.Merge
-    selection:
-        inherited_members: true

--- a/docs/api/Missing.md
+++ b/docs/api/Missing.md
@@ -1,6 +1,0 @@
-
-# treeo.Missing
-
-::: treeo.Missing
-    selection:
-        inherited_members: true

--- a/docs/api/NOTHING.md
+++ b/docs/api/NOTHING.md
@@ -1,6 +1,0 @@
-
-# treeo.NOTHING
-
-::: treeo.NOTHING
-    selection:
-        inherited_members: true

--- a/docs/api/Nothing.md
+++ b/docs/api/Nothing.md
@@ -1,6 +1,0 @@
-
-# treeo.Nothing
-
-::: treeo.Nothing
-    selection:
-        inherited_members: true

--- a/docs/api/Opaque.md
+++ b/docs/api/Opaque.md
@@ -1,6 +1,0 @@
-
-# treeo.Opaque
-
-::: treeo.Opaque
-    selection:
-        inherited_members: true

--- a/docs/api/OpaquePredicate.md
+++ b/docs/api/OpaquePredicate.md
@@ -1,6 +1,0 @@
-
-# treeo.OpaquePredicate
-
-::: treeo.OpaquePredicate
-    selection:
-        inherited_members: true

--- a/docs/api/Repr.md
+++ b/docs/api/Repr.md
@@ -1,6 +1,0 @@
-
-# treeo.Repr
-
-::: treeo.Repr
-    selection:
-        inherited_members: true

--- a/docs/api/ToDict.md
+++ b/docs/api/ToDict.md
@@ -1,6 +1,0 @@
-
-# treeo.ToDict
-
-::: treeo.ToDict
-    selection:
-        inherited_members: true

--- a/docs/api/ToString.md
+++ b/docs/api/ToString.md
@@ -1,6 +1,0 @@
-
-# treeo.ToString
-
-::: treeo.ToString
-    selection:
-        inherited_members: true

--- a/docs/api/Tree.md
+++ b/docs/api/Tree.md
@@ -1,6 +1,0 @@
-
-# treeo.Tree
-
-::: treeo.Tree
-    selection:
-        inherited_members: true

--- a/docs/api/TreeMeta.md
+++ b/docs/api/TreeMeta.md
@@ -1,6 +1,0 @@
-
-# treeo.TreeMeta
-
-::: treeo.TreeMeta
-    selection:
-        inherited_members: true

--- a/docs/api/add_field_info.md
+++ b/docs/api/add_field_info.md
@@ -1,6 +1,0 @@
-
-# treeo.add_field_info
-
-::: treeo.add_field_info
-    selection:
-        inherited_members: true

--- a/docs/api/apply.md
+++ b/docs/api/apply.md
@@ -1,6 +1,0 @@
-
-# treeo.apply
-
-::: treeo.apply
-    selection:
-        inherited_members: true

--- a/docs/api/compact.md
+++ b/docs/api/compact.md
@@ -1,6 +1,0 @@
-
-# treeo.compact
-
-::: treeo.compact
-    selection:
-        inherited_members: true

--- a/docs/api/copy.md
+++ b/docs/api/copy.md
@@ -1,6 +1,0 @@
-
-# treeo.copy
-
-::: treeo.copy
-    selection:
-        inherited_members: true

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -1,6 +1,0 @@
-
-# treeo.field
-
-::: treeo.field
-    selection:
-        inherited_members: true

--- a/docs/api/filter.md
+++ b/docs/api/filter.md
@@ -1,6 +1,0 @@
-
-# treeo.filter
-
-::: treeo.filter
-    selection:
-        inherited_members: true

--- a/docs/api/flatten_mode.md
+++ b/docs/api/flatten_mode.md
@@ -1,6 +1,0 @@
-
-# treeo.flatten_mode
-
-::: treeo.flatten_mode
-    selection:
-        inherited_members: true

--- a/docs/api/in_compact.md
+++ b/docs/api/in_compact.md
@@ -1,6 +1,0 @@
-
-# treeo.in_compact
-
-::: treeo.in_compact
-    selection:
-        inherited_members: true

--- a/docs/api/map.md
+++ b/docs/api/map.md
@@ -1,6 +1,0 @@
-
-# treeo.map
-
-::: treeo.map
-    selection:
-        inherited_members: true

--- a/docs/api/merge.md
+++ b/docs/api/merge.md
@@ -1,6 +1,0 @@
-
-# treeo.merge
-
-::: treeo.merge
-    selection:
-        inherited_members: true

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1,6 +1,0 @@
-
-# treeo.node
-
-::: treeo.node
-    selection:
-        inherited_members: true

--- a/docs/api/static.md
+++ b/docs/api/static.md
@@ -1,6 +1,0 @@
-
-# treeo.static
-
-::: treeo.static
-    selection:
-        inherited_members: true

--- a/docs/api/to_dict.md
+++ b/docs/api/to_dict.md
@@ -1,6 +1,0 @@
-
-# treeo.to_dict
-
-::: treeo.to_dict
-    selection:
-        inherited_members: true

--- a/docs/api/to_string.md
+++ b/docs/api/to_string.md
@@ -1,6 +1,0 @@
-
-# treeo.to_string
-
-::: treeo.to_string
-    selection:
-        inherited_members: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ nav:
     Filter: api/Filter.md
     FlattenMode: api/FlattenMode.md
     Hashable: api/Hashable.md
+    Immutable: api/Immutable.md
+    ImmutableTree: api/ImmutableTree.md
     KindMixin: api/KindMixin.md
     MISSING: api/MISSING.md
     Map: api/Map.md
@@ -56,6 +58,7 @@ nav:
     in_compact: api/in_compact.md
     map: api/map.md
     merge: api/merge.md
+    mutable: api/mutable.md
     node: api/node.md
     static: api/static.md
     to_dict: api/to_dict.md

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -68,6 +68,16 @@ class TestImmutable:
         with pytest.raises(RuntimeError):
             y = linear(x)
 
+    def test_mutable_functional(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        y, linear2 = to.mutable(Linear.__call__)(linear, x)
+
+        assert y.shape == (5, 3)
+        assert isinstance(linear2, Linear)
+        assert linear is not linear2
+
     def test_mutable_no_arg(self):
         x = np.random.uniform(size=(5, 2))
         linear = Linear(2, 3)

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -108,6 +108,39 @@ class TestImmutable:
         assert isinstance(linear2, Linear)
         assert linear is not linear2
 
+    def test_mutable_submodule(self):
+        class Parent(to.Tree, to.Immutable):
+            def __init__(self):
+                self.child = Child()
+
+            def __call__(self, x):
+                return self.child(x)
+
+        class Child(to.Tree, to.Immutable):
+            n: int = to.node()
+
+            def __init__(self):
+                self.n = 0
+
+            def __call__(self, x):
+                self.n += 1
+                return x
+
+        x = np.random.uniform(size=(5, 2))
+        module = Parent()
+
+        with pytest.raises(RuntimeError):
+            y = module(x)
+
+        assert module.child.n == 0
+
+        y, module2 = module.mutable(x)
+
+        assert y.shape == (5, 2)
+        assert isinstance(module2, Parent)
+        assert module is not module2
+        assert module2.child.n == 1
+
     def test_default(self):
         class A(to.Tree, to.Immutable):
             a: int = to.field(1, node=True)

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -72,7 +72,7 @@ class TestImmutable:
         x = np.random.uniform(size=(5, 2))
         linear = Linear(2, 3)
 
-        y, linear2 = linear.mutable_call(x)
+        y, linear2 = linear.mutable(x)
 
         assert y.shape == (5, 3)
         assert isinstance(linear2, Linear)
@@ -82,7 +82,7 @@ class TestImmutable:
         x = np.random.uniform(size=(5, 2))
         linear = Linear(2, 3)
 
-        y, linear2 = linear.mutable_call(x, method=linear.__call__)
+        y, linear2 = linear.mutable(x, method=linear.__call__)
 
         assert y.shape == (5, 3)
         assert isinstance(linear2, Linear)
@@ -92,7 +92,7 @@ class TestImmutable:
         x = np.random.uniform(size=(5, 2))
         linear = Linear(2, 3)
 
-        y, linear2 = linear.mutable_call(x, method=Linear.__call__)
+        y, linear2 = linear.mutable(x, method=Linear.__call__)
 
         assert y.shape == (5, 3)
         assert isinstance(linear2, Linear)
@@ -102,7 +102,7 @@ class TestImmutable:
         x = np.random.uniform(size=(5, 2))
         linear = Linear(2, 3)
 
-        y, linear2 = linear.mutable_call(x, method="double")
+        y, linear2 = linear.mutable(x, method="double")
 
         assert y.shape == (5, 3)
         assert isinstance(linear2, Linear)

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -1,0 +1,1193 @@
+import typing as tp
+from dataclasses import dataclass
+from inspect import Parameter
+
+import jax
+import jax.numpy as jnp
+import jax.tree_util
+import numpy as np
+import pytest
+
+import treeo as to
+from treeo.api import T, add_field_info, map
+from treeo.tree import Tree
+from treeo.utils import field
+
+
+class Parameter(to.KindMixin):
+    pass
+
+
+class State(to.KindMixin):
+    pass
+
+
+class Linear(to.Tree, to.Immutable):
+    w: np.ndarray = Parameter.node()
+    b: np.ndarray = Parameter.node()
+    n: int = State.node()
+
+    def __init__(self, din, dout, name="linear"):
+        self.din = din
+        self.dout = dout
+        self.w = np.random.uniform(size=(din, dout))
+        self.b = np.random.uniform(size=(dout,))
+        self.n = 1
+        self.name = name
+
+    def __call__(self, x):
+        self.n += 1
+        return jnp.dot(x, self.w) + self.b
+
+    def double(self, x):
+        return self(x) * 2.0
+
+
+class MLP(to.Tree, to.Immutable):
+    linear1: Linear
+    linear2: Linear
+
+    def __init__(self, din, dmid, dout, name="mlp"):
+        self.din = din
+        self.dmid = dmid
+        self.dout = dout
+        self.name = name
+
+        self.linear1 = Linear(din, dmid)
+        self.linear2 = Linear(dmid, dout)
+
+    def __call__(self, x):
+        return self.linear2(self.linear1(x))
+
+
+class TestImmutable:
+    def test_mutable_error(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        with pytest.raises(RuntimeError):
+            y = linear(x)
+
+    def test_mutable_no_arg(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        y, linear2 = linear.mutable_call(x)
+
+        assert y.shape == (5, 3)
+        assert isinstance(linear2, Linear)
+        assert linear is not linear2
+
+    def test_mutable_bounded_method(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        y, linear2 = linear.mutable_call(x, method=linear.__call__)
+
+        assert y.shape == (5, 3)
+        assert isinstance(linear2, Linear)
+        assert linear is not linear2
+
+    def test_mutable_unbounded_method(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        y, linear2 = linear.mutable_call(x, method=Linear.__call__)
+
+        assert y.shape == (5, 3)
+        assert isinstance(linear2, Linear)
+        assert linear is not linear2
+
+    def test_mutable_string_method(self):
+        x = np.random.uniform(size=(5, 2))
+        linear = Linear(2, 3)
+
+        y, linear2 = linear.mutable_call(x, method="double")
+
+        assert y.shape == (5, 3)
+        assert isinstance(linear2, Linear)
+        assert linear is not linear2
+
+    def test_default(self):
+        class A(to.Tree, to.Immutable):
+            a: int = to.field(1, node=True)
+
+        tree = A()
+
+        assert tree.a == 1
+
+        tree = jax.tree_map(lambda x: 2 * x, tree)
+
+        assert tree.a == 2
+
+    def test_default_factory(self):
+        class A(to.Tree, to.Immutable):
+            a: int = to.field(node=True, default_factory=lambda: 1)
+
+        tree = A()
+
+        assert tree.a == 1
+
+        tree = jax.tree_map(lambda x: 2 * x, tree)
+
+        assert tree.a == 2
+
+    def test_flatten(self):
+
+        mlp = MLP(2, 3, 5)
+
+        flat = jax.tree_leaves(mlp)
+
+        assert len(flat) == 6
+
+    def test_flatten_slice(self):
+
+        mlp = to.filter(MLP(2, 3, 5), State)
+
+        flat = jax.tree_leaves(mlp)
+
+        assert len(flat) == 2
+
+    def test_flatten_slice_merging(self):
+
+        mlp = to.filter(MLP(2, 3, 5), State)
+
+        flat = jax.tree_flatten(mlp, lambda x: isinstance(x, to.Nothing))[0]
+
+        assert len(flat) == 6
+
+    def test_is_tree(self):
+
+        mlp = MLP(2, 3, 5)
+
+        @jax.jit
+        def idfn(x):
+            return x
+
+        assert not isinstance(mlp.linear1.w, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.b, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        assert not isinstance(mlp.linear2.w, jnp.DeviceArray)
+        assert not isinstance(mlp.linear2.b, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        mlp = idfn(mlp)
+
+        assert isinstance(mlp.linear1.w, jnp.DeviceArray)
+        assert isinstance(mlp.linear1.b, jnp.DeviceArray)
+        assert isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        assert isinstance(mlp.linear2.w, jnp.DeviceArray)
+        assert isinstance(mlp.linear2.b, jnp.DeviceArray)
+        assert isinstance(mlp.linear2.n, jnp.DeviceArray)
+
+    def test_update_field_metadata(self):
+
+        mlp = MLP(2, 3, 5)
+
+        mlp = mlp.replace(linear1=mlp.linear1.update_field_metadata("w", node=False))
+
+        @jax.jit
+        def idfn(x):
+            return x
+
+        assert not isinstance(mlp.linear1.w, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.b, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        assert not isinstance(mlp.linear2.w, jnp.DeviceArray)
+        assert not isinstance(mlp.linear2.b, jnp.DeviceArray)
+        assert not isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        mlp = idfn(mlp)
+
+        assert not isinstance(mlp.linear1.w, jnp.DeviceArray)
+        assert isinstance(mlp.linear1.b, jnp.DeviceArray)
+        assert isinstance(mlp.linear1.n, jnp.DeviceArray)
+
+        assert isinstance(mlp.linear2.w, jnp.DeviceArray)
+        assert isinstance(mlp.linear2.b, jnp.DeviceArray)
+        assert isinstance(mlp.linear2.n, jnp.DeviceArray)
+
+    def test_filter(self):
+
+        mlp = MLP(2, 3, 5)
+
+        # params
+        mlp_params = to.filter(mlp, Parameter)
+
+        assert not isinstance(mlp_params.linear1.w, to.Nothing)
+        assert not isinstance(mlp_params.linear1.b, to.Nothing)
+        assert isinstance(mlp_params.linear1.n, to.Nothing)
+
+        assert not isinstance(mlp_params.linear2.w, to.Nothing)
+        assert not isinstance(mlp_params.linear2.b, to.Nothing)
+        assert isinstance(mlp_params.linear2.n, to.Nothing)
+
+        # states
+        mlp_states = to.filter(mlp, State)
+
+        assert isinstance(mlp_states.linear1.w, to.Nothing)
+        assert isinstance(mlp_states.linear1.b, to.Nothing)
+        assert not isinstance(mlp_states.linear1.n, to.Nothing)
+
+        assert isinstance(mlp_states.linear2.w, to.Nothing)
+        assert isinstance(mlp_states.linear2.b, to.Nothing)
+        assert not isinstance(mlp_states.linear2.n, to.Nothing)
+
+    def test_update(self):
+
+        mlp = MLP(2, 3, 5)
+
+        mlp_params = to.filter(mlp, Parameter)
+        mlp_states = to.filter(mlp, State)
+
+        mlp_next = to.merge(mlp_params, mlp_states)
+
+        assert not isinstance(mlp_next.linear1.w, to.Nothing)
+        assert not isinstance(mlp_next.linear1.b, to.Nothing)
+        assert not isinstance(mlp_next.linear1.n, to.Nothing)
+
+        assert not isinstance(mlp_next.linear2.w, to.Nothing)
+        assert not isinstance(mlp_next.linear2.b, to.Nothing)
+        assert not isinstance(mlp_next.linear2.n, to.Nothing)
+
+    def test_update_not_inplace(self):
+
+        mlp = MLP(2, 3, 5)
+
+        mlp_params = to.filter(mlp, Parameter)
+        mlp_states = to.filter(mlp, State)
+
+        to.merge(mlp_params, mlp_states)
+
+        assert not isinstance(mlp_params.linear1.w, to.Nothing)
+        assert not isinstance(mlp_params.linear1.b, to.Nothing)
+        assert isinstance(mlp_params.linear1.n, to.Nothing)
+
+        assert not isinstance(mlp_params.linear2.w, to.Nothing)
+        assert not isinstance(mlp_params.linear2.b, to.Nothing)
+        assert isinstance(mlp_params.linear2.n, to.Nothing)
+
+    def test_list(self):
+        class LinearList(to.Tree, to.Immutable):
+            params: tp.List[np.ndarray] = Parameter.node()
+
+            def __init__(self, din, dout, name="linear"):
+                super().__init__()
+
+                self.din = din
+                self.dout = dout
+                self.params = [
+                    np.random.uniform(size=(din, dout)),
+                    np.random.uniform(size=(dout,)),
+                ]
+                self.name = name
+
+        linear = LinearList(2, 3, name="mlp")
+
+        @jax.jit
+        def idfn(x):
+            return x
+
+        assert not isinstance(linear.params[0], jnp.DeviceArray)
+        assert not isinstance(linear.params[1], jnp.DeviceArray)
+
+        linear = idfn(linear)
+
+        assert isinstance(linear.params[0], jnp.DeviceArray)
+        assert isinstance(linear.params[1], jnp.DeviceArray)
+
+    def test_treelist(self):
+        class MLP(to.Tree, to.Immutable):
+            linears: tp.List[Linear]
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                super().__init__()
+                self.linears = [
+                    Linear(din, dmid, name="linear1"),
+                    Linear(dmid, dout, name="linear2"),
+                ]
+
+        mlp = MLP(2, 3, 5)
+
+        @jax.jit
+        def idfn(x):
+            return x
+
+        assert not isinstance(mlp.linears[0].w, jnp.DeviceArray)
+        assert not isinstance(mlp.linears[0].b, jnp.DeviceArray)
+        assert not isinstance(mlp.linears[0].n, jnp.DeviceArray)
+
+        assert not isinstance(mlp.linears[1].w, jnp.DeviceArray)
+        assert not isinstance(mlp.linears[1].b, jnp.DeviceArray)
+        assert not isinstance(mlp.linears[1].n, jnp.DeviceArray)
+
+        mlp = idfn(mlp)
+
+        assert isinstance(mlp.linears[0].w, jnp.DeviceArray)
+        assert isinstance(mlp.linears[0].b, jnp.DeviceArray)
+        assert isinstance(mlp.linears[0].n, jnp.DeviceArray)
+
+        assert isinstance(mlp.linears[1].w, jnp.DeviceArray)
+        assert isinstance(mlp.linears[1].b, jnp.DeviceArray)
+        assert isinstance(mlp.linears[1].n, jnp.DeviceArray)
+
+    def test_static_annotation(self):
+        class Mod(to.Tree, to.Immutable):
+            a: Linear
+            b: Linear = to.static()
+
+            def __init__(self):
+                super().__init__()
+                self.a = Linear(3, 4)
+                self.b = Linear(3, 4)
+
+        mod = Mod()
+
+        mod: Mod = jax.tree_map(lambda x: "abc", mod)
+
+        assert len(jax.tree_leaves(mod)) == 3
+
+        assert isinstance(mod.a.w, str)
+        assert isinstance(mod.a.b, str)
+        assert isinstance(mod.a.n, str)
+
+        assert not isinstance(mod.b.w, str)
+        assert not isinstance(mod.b.b, str)
+        assert not isinstance(mod.b.n, str)
+
+    def test_auto_annotations(self):
+        class MLP(to.Tree, to.Immutable):
+            def __init__(self, din, dmid, dout, name="mlp"):
+                super().__init__()
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+                self.linear1 = Linear(din, dmid, name="linear1")
+                self.linear2 = Linear(dmid, dout, name="linear2")
+
+        mlp = MLP(2, 3, 5)
+
+        assert "linear1" in mlp.field_metadata
+
+    def test_auto_annotations_inserted(self):
+        class MLP(to.Tree, to.Immutable):
+            def __init__(self, din, dmid, dout, name="mlp"):
+                super().__init__()
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+                self.linear1 = Linear(din, dmid, name="linear1")
+                self.linear2 = Linear(dmid, dout, name="linear2")
+
+        mlp = MLP(2, 3, 5)
+
+        mlp = mlp.replace(linear3=Linear(7, 8, name="linear3"))
+
+        jax.tree_leaves(mlp)  # force flatten
+
+        assert "linear3" in mlp.field_metadata
+
+    def test_auto_annotations_static(self):
+        class MLP(to.Tree, to.Immutable):
+            linear2: Linear = to.static()
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                super().__init__()
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+                self.linear1 = Linear(din, dmid, name="linear1")
+                self.linear2 = Linear(dmid, dout, name="linear2")
+
+        mlp = MLP(2, 3, 5)
+
+        assert "linear1" in mlp.field_metadata
+        assert not mlp.field_metadata["linear2"].node
+
+    def test_annotations_missing_field_no_error(self):
+        class MLP(to.Tree, to.Immutable):
+            linear3: Linear  # missing field
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                super().__init__()
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+                self.linear1 = Linear(din, dmid, name="linear1")
+                self.linear2 = Linear(dmid, dout, name="linear2")
+
+        mlp = MLP(2, 3, 5)
+
+        assert "linear1" in mlp.field_metadata
+        assert "linear2" in mlp.field_metadata
+
+    def test_treex_filter(self):
+
+        tree = dict(a=1, b=Linear(3, 4))
+
+        tree2 = to.filter(tree, Parameter)
+        assert isinstance(tree2["a"], to.Nothing)
+
+        tree2 = to.filter(tree, lambda field: isinstance(field.value, int))
+        assert tree2["a"] == 1
+
+    def test_treex_filter_inplace(self):
+
+        tree = Linear(3, 4)
+
+        with pytest.raises(RuntimeError):
+            tree2 = to.filter(tree, Parameter, inplace=True)
+
+    def test_module_map(self):
+        class A(to.Tree, to.Immutable):
+            def __init__(self):
+                super().__init__()
+                self.a = 1
+
+        module = A()
+
+        def map_fn(x):
+            x.a = 2
+
+        module2 = to.apply(map_fn, module)
+        assert module.a == 1
+        assert module2.a == 2
+
+    def test_opaque(self):
+        class A(to.Tree, to.Immutable):
+            id: to.Opaque[str]
+
+            def __init__(self, id: str):
+                self.id = to.Opaque(id, None)
+
+        a1 = A("1")
+        a2 = A("2")
+
+        n = 0
+
+        @jax.jit
+        def f(a):
+            nonlocal n
+            n += 1
+
+        f(a1)
+        f(a2)
+
+        assert n == 1
+
+    def test_opaque_field(self):
+        class A(to.Tree, to.Immutable):
+            id: str = to.field(node=False, opaque=True)
+
+            def __init__(self, id: str):
+                self.id = id
+
+        a1 = A("1")
+        a2 = A("2")
+
+        n = 0
+
+        @jax.jit
+        def f(a):
+            nonlocal n
+            n += 1
+
+        f(a1)
+        f(a2)
+
+        assert n == 1
+
+    def test_opaque_field_array(self):
+        class A(to.Tree, to.Immutable):
+            array: np.ndarray = to.field(node=False, opaque=True)
+
+            def __init__(self, array: np.ndarray):
+                self.array = array
+
+        a1 = A(np.array(1))
+        a2 = A(np.array(2))
+
+        n = 0
+
+        @jax.jit
+        def f(a):
+            nonlocal n
+            n += 1
+
+        f(a1)
+        f(a2)
+
+        assert n == 1
+
+        a3 = A(np.array([1, 2]))
+
+        f(a3)
+
+        assert n == 2
+
+    def test_hashable(self):
+        class A(to.Tree, to.Immutable):
+            array: to.Hashable[np.ndarray]
+
+            def __init__(self, array: np.ndarray):
+                self.array = to.Hashable(array)
+
+        tree = A(np.array(1))
+
+        n = 0
+
+        @jax.jit
+        def f(tree):
+            nonlocal n
+            n += 1
+
+        f(tree)
+        assert n == 1
+
+        f(tree)
+        assert n == 1
+
+        tree = tree.replace(array=to.Hashable(np.array(2)))
+        f(tree)
+
+        assert n == 2
+
+    def test_generics(self):
+        class A(to.Tree, to.Immutable):
+            w: jnp.ndarray = Parameter.node()
+
+            def __init__(self, w: jnp.ndarray):
+                self.w = w
+
+        class MyTree(to.Tree, to.Immutable):
+            tree_or_array: tp.List[tp.Union[jnp.ndarray, A]]
+
+            def __init__(self, tree_or_array: tp.List[tp.Union[jnp.ndarray, A]]):
+                self.tree_or_array = tree_or_array
+
+        module = MyTree(
+            [
+                jnp.ones(shape=[10, 5]),
+                A(jnp.array([10.0])),
+            ]
+        )
+        assert isinstance(module.tree_or_array[1], A)
+
+        params = to.filter(module, Parameter)
+
+        assert module.field_metadata["tree_or_array"].kind == type(None)
+        assert module.tree_or_array[1].field_metadata["w"].kind == Parameter
+
+        with to.add_field_info():
+            infos = jax.tree_leaves(module)
+
+        assert infos[0].kind == type(None)
+        assert infos[1].kind == Parameter
+
+    def test_update_all_fields(self):
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: int = to.field(node=False)
+
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        a1 = A(1, 2)
+        a2 = A(to.NOTHING, 4)
+        a3 = A(5, to.NOTHING)
+
+        aout = to.merge(a1, a2, a3)
+
+        assert aout.x == 5
+        assert aout.y == 4
+
+    def test_update_normal(self):
+        """
+        In this test the static part of `a1` is use of `aout` since `flatten_mode` is set to `normal`.
+        """
+
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: int = to.field(node=False, opaque=True)
+
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        a1 = A(1, 2)
+        a2 = A(to.NOTHING, 3)
+        a3 = A(5, 4)
+
+        aout = to.merge(a1, a2, a3, flatten_mode=to.FlattenMode.normal)
+
+        assert aout.x == 5
+        assert aout.y == 2
+
+    def test_update_normal_ignore_static(self):
+        """
+        ignore_static enables you to ignore differences in the static structure of the trees.
+        """
+
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: int = to.field(node=False)
+
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        a1 = A(1, 2)
+        a2 = A(to.NOTHING, 3)
+        a3 = A(5, to.NOTHING)
+
+        aout = to.merge(
+            a1, a2, a3, flatten_mode=to.FlattenMode.normal, ignore_static=True
+        )
+
+        assert aout.x == 5
+        assert aout.y == 2
+
+    def test_update_normal_ignore_static_false_raises(self):
+        """
+        ignore_static enables you to ignore differences in the static structure of the trees.
+        """
+
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: int = to.field(node=False)
+
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        a1 = A(1, 2)
+        a2 = A(to.NOTHING, 3)
+        a3 = A(5, to.NOTHING)
+
+        with pytest.raises(ValueError):
+            aout = to.merge(
+                a1, a2, a3, flatten_mode=to.FlattenMode.normal, ignore_static=False
+            )
+
+    def test_update_inplace(self):
+        """
+        In this test the static part of `a1` is use of `aout` since `flatten_mode` is set to `normal`.
+        """
+
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: int = to.field(node=False)
+
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        a1 = A(1, 2)
+        a2 = A(to.NOTHING, 4)
+        a3 = A(5, to.NOTHING)
+
+        with pytest.raises(RuntimeError):
+            to.merge(a1, a2, a3, inplace=True)
+
+    def test_jit_on_method(self):
+        n = 0
+
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+
+            def __init__(self, x: int):
+                self.x = x
+
+            @jax.jit
+            @to.mutable
+            def f(self):
+                nonlocal n
+                n += 1
+                self.x = self.x + 1
+
+        a = A(1)
+
+        _, a = a.f()
+
+        assert a.x == 2
+        assert n == 1
+
+        _, a = a.f()
+        assert a.x == 3
+        assert n == 1
+
+    def test_to_dict(self):
+        @dataclass
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: str = to.field(node=False)
+
+        @dataclass
+        class B(to.Tree, to.Immutable):
+            list_of_a: tp.List[A] = to.field(node=True)
+            dict_of_a: tp.Dict[str, A] = to.field(node=False)
+
+        a1 = A(1, "abc")
+        a2 = A(3, "def")
+        a3 = A(5, "ghi")
+        a4 = A(7, "jkl")
+        a5 = A(9, "mno")
+        a6 = A(11, "pqr")
+
+        b = B([a1, a2, a3], {"a": a4, "b": a5, "c": a6})
+
+        d = to.to_dict(b)
+
+        assert d == {
+            "list_of_a": [
+                {"x": 1, "y": "abc"},
+                {"x": 3, "y": "def"},
+                {"x": 5, "y": "ghi"},
+            ],
+            "dict_of_a": {
+                "a": {"x": 7, "y": "jkl"},
+                "b": {"x": 9, "y": "mno"},
+                "c": {"x": 11, "y": "pqr"},
+            },
+        }
+
+    def test_to_dict_type_info(self):
+        @dataclass
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: str = to.field(node=False)
+
+        @dataclass
+        class B(to.Tree, to.Immutable):
+            list_of_a: tp.List[A] = to.field(node=True)
+            dict_of_a: tp.Dict[str, A] = to.field(node=False)
+
+        a1 = A(1, "abc")
+        a2 = A(3, "def")
+        a3 = A(5, "ghi")
+        a4 = A(7, "jkl")
+        a5 = A(9, "mno")
+        a6 = A(11, "pqr")
+
+        b = B([a1, a2, a3], {"a": a4, "b": a5, "c": a6})
+
+        d = to.to_dict(b, type_info=True)
+
+        assert d == {
+            "list_of_a": [
+                {"x": 1, "y": "abc", "__type__": A},
+                {"x": 3, "y": "def", "__type__": A},
+                {"x": 5, "y": "ghi", "__type__": A},
+                list,
+            ],
+            "dict_of_a": {
+                "a": {"x": 7, "y": "jkl", "__type__": A},
+                "b": {"x": 9, "y": "mno", "__type__": A},
+                "c": {"x": 11, "y": "pqr", "__type__": A},
+                "__type__": dict,
+            },
+            "__type__": B,
+        }
+
+    def test_to_dict_field_info(self):
+        @dataclass
+        class A(to.Tree, to.Immutable):
+            x: int = to.field(node=True)
+            y: str = to.field(node=False)
+
+        @dataclass
+        class B(to.Tree, to.Immutable):
+            list_of_a: tp.List[A] = to.field(node=True)
+            dict_of_a: tp.Dict[str, A] = to.field(node=False)
+
+        a1 = A(1, "abc")
+        a2 = A(3, "def")
+        a3 = A(5, "ghi")
+        a4 = A(7, "jkl")
+        a5 = A(9, "mno")
+        a6 = A(11, "pqr")
+
+        b = B([a1, a2, a3], {"a": a4, "b": a5, "c": a6})
+
+        d = to.to_dict(b, field_info=True)
+
+        assert isinstance(d["list_of_a"][0]["x"], to.FieldInfo)
+        assert isinstance(d["list_of_a"][0]["y"], to.FieldInfo)
+        assert isinstance(d["list_of_a"][1]["x"], to.FieldInfo)
+        assert isinstance(d["list_of_a"][1]["y"], to.FieldInfo)
+        assert isinstance(d["list_of_a"][2]["x"], to.FieldInfo)
+        assert isinstance(d["list_of_a"][2]["y"], to.FieldInfo)
+
+        assert isinstance(d["dict_of_a"]["a"]["x"], to.FieldInfo)
+        assert isinstance(d["dict_of_a"]["a"]["y"], to.FieldInfo)
+        assert isinstance(d["dict_of_a"]["b"]["x"], to.FieldInfo)
+        assert isinstance(d["dict_of_a"]["b"]["y"], to.FieldInfo)
+        assert isinstance(d["dict_of_a"]["c"]["x"], to.FieldInfo)
+        assert isinstance(d["dict_of_a"]["c"]["y"], to.FieldInfo)
+
+    def test_to_string(self):
+        @dataclass
+        class A(to.Tree, to.Immutable):
+            x: np.ndarray = to.field(node=True, kind=Parameter)
+            y: str = to.field(node=False, kind=State)
+
+        @dataclass
+        class B(to.Tree, to.Immutable):
+            list_of_a: tp.List[A] = to.field(node=True)
+            dict_of_a: tp.Dict[str, A] = to.field(node=False)
+
+        a1 = A(np.zeros((2, 4)), "abc")
+        a2 = A(jnp.zeros((2, 4)), "def")
+        a3 = A(np.zeros((2, 4)), "ghi")
+        a4 = A(jnp.zeros((2, 4)), "jkl")
+        a5 = A(np.zeros((2, 4)), "mno")
+        a6 = A(jnp.zeros((2, 4)), "pqr")
+
+        b = B([a1, a2, a3], {"a": a4, "b": a5, "c": a6})
+
+        rep = to.to_string(b, color=True)
+
+        print(rep)
+
+    def test_compact(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            w: np.ndarray = Parameter.node()
+            b: np.ndarray = Parameter.node()
+            n: int = State.node()
+
+            def __init__(self, din, dout, name="linear"):
+                self.din = din
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+                b = self.get_field("b", lambda: np.random.uniform(size=(self.dout,)))
+                n = self.get_field("n", lambda: 1)
+
+        class MLP(to.Tree, to.Immutable):
+            linear1: Linear
+            linear2: Linear
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                Linear(self.din, self.dmid, name="linear1")()
+                Linear(self.dmid, self.dout, name="linear2")()
+
+        mlp = MLP(2, 4, 3)
+        mlp()
+        mlp()
+
+        assert mlp.linear1.w.shape == (2, 4)
+        assert mlp.linear1.b.shape == (4,)
+        assert mlp.linear1.n == 1
+
+        assert mlp.linear2.w.shape == (4, 3)
+        assert mlp.linear2.b.shape == (3,)
+        assert mlp.linear2.n == 1
+
+        assert mlp.linear1.name == "linear1"
+        assert mlp.linear2.name == "linear2"
+        assert mlp.name == "mlp"
+
+        flat = jax.tree_leaves(mlp)
+
+        assert len(flat) == 6
+
+        # params
+        mlp_params = to.filter(mlp, Parameter)
+
+        assert not isinstance(mlp_params.linear1.w, to.Nothing)
+        assert not isinstance(mlp_params.linear1.b, to.Nothing)
+        assert isinstance(mlp_params.linear1.n, to.Nothing)
+
+        assert not isinstance(mlp_params.linear2.w, to.Nothing)
+        assert not isinstance(mlp_params.linear2.b, to.Nothing)
+        assert isinstance(mlp_params.linear2.n, to.Nothing)
+
+        # states
+        mlp_states = to.filter(mlp, State)
+
+        assert isinstance(mlp_states.linear1.w, to.Nothing)
+        assert isinstance(mlp_states.linear1.b, to.Nothing)
+        assert not isinstance(mlp_states.linear1.n, to.Nothing)
+
+        assert isinstance(mlp_states.linear2.w, to.Nothing)
+        assert isinstance(mlp_states.linear2.b, to.Nothing)
+        assert not isinstance(mlp_states.linear2.n, to.Nothing)
+
+    def test_compact_sugar(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            w: np.ndarray = Parameter.node()
+            b: np.ndarray = Parameter.node()
+            n: int = State.node()
+
+            def __init__(self, din, dout, name="linear"):
+                self.din = din
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+                b = self.get_field("b", lambda: np.random.uniform(size=(self.dout,)))
+                n = self.get_field("n", lambda: 1)
+
+        class MLP(to.Tree, to.Immutable):
+            linear1: Linear
+            linear2: Linear
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                Linear(self.din, self.dmid, name="linear1")()
+                Linear(self.dmid, self.dout, name="linear2")()
+
+        mlp = MLP(2, 4, 3)
+        mlp()
+        mlp()
+
+        assert mlp.linear1.w.shape == (2, 4)
+        assert mlp.linear1.b.shape == (4,)
+        assert mlp.linear1.n == 1
+
+        assert mlp.linear2.w.shape == (4, 3)
+        assert mlp.linear2.b.shape == (3,)
+        assert mlp.linear2.n == 1
+
+        assert mlp.linear1.name == "linear1"
+        assert mlp.linear2.name == "linear2"
+        assert mlp.name == "mlp"
+
+        flat = jax.tree_leaves(mlp)
+
+        assert len(flat) == 6
+
+        # params
+        mlp_params = to.filter(mlp, Parameter)
+
+        assert not isinstance(mlp_params.linear1.w, to.Nothing)
+        assert not isinstance(mlp_params.linear1.b, to.Nothing)
+        assert isinstance(mlp_params.linear1.n, to.Nothing)
+
+        assert not isinstance(mlp_params.linear2.w, to.Nothing)
+        assert not isinstance(mlp_params.linear2.b, to.Nothing)
+        assert isinstance(mlp_params.linear2.n, to.Nothing)
+
+        # states
+        mlp_states = to.filter(mlp, State)
+
+        assert isinstance(mlp_states.linear1.w, to.Nothing)
+        assert isinstance(mlp_states.linear1.b, to.Nothing)
+        assert not isinstance(mlp_states.linear1.n, to.Nothing)
+
+        assert isinstance(mlp_states.linear2.w, to.Nothing)
+        assert isinstance(mlp_states.linear2.b, to.Nothing)
+        assert not isinstance(mlp_states.linear2.n, to.Nothing)
+
+    def test_compact_naming(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            w: np.ndarray = Parameter.node()
+            b: np.ndarray = Parameter.node()
+            n: int = State.node()
+
+            def __init__(self, din, dout):
+                self.din = din
+                self.dout = dout
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+                b = self.get_field("b", lambda: np.random.uniform(size=(self.dout,)))
+                n = self.get_field("n", lambda: 1)
+
+        class MLP(to.Tree, to.Immutable):
+            linear: Linear
+            linear2: Linear
+
+            def __init__(self, din, dmid, dout, name="mlp"):
+                self.din = din
+                self.dmid = dmid
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                Linear(self.din, self.dmid)()
+                Linear(self.dmid, self.dout)()
+
+        mlp = MLP(2, 4, 3)
+        mlp()
+        mlp()
+
+        assert mlp.linear.w.shape == (2, 4)
+        assert mlp.linear.b.shape == (4,)
+        assert mlp.linear.n == 1
+
+        assert mlp.linear2.w.shape == (4, 3)
+        assert mlp.linear2.b.shape == (3,)
+        assert mlp.linear2.n == 1
+
+        assert hasattr(mlp, "linear")
+        assert hasattr(mlp, "linear2")
+
+        assert mlp.linear.din == 2
+        assert mlp.linear.dout == 4
+
+        assert mlp.linear2.din == 4
+        assert mlp.linear2.dout == 3
+
+    def test_compact_error_no_annotations(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            def __init__(self, din, dout, name="linear"):
+                self.din = din
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+
+        tree = Linear(2, 4)
+
+        with pytest.raises(ValueError):
+            tree()
+
+    def test_compact_override_ok(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            w: np.ndarray = Parameter.node()
+
+            def __init__(self, din, dout, name="linear"):
+                self.din = din
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+
+        class NewLinear(Linear):
+            b: np.ndarray = Parameter.node()
+
+            @to.compact
+            def __call__(self):
+                b = self.get_field("b", lambda: np.random.uniform(size=(self.dout,)))
+                super().__call__()
+
+        tree = NewLinear(2, 4)
+
+        tree()
+
+        assert tree.w.shape == (2, 4)
+        assert tree.b.shape == (4,)
+
+    def test_compact_recursion_error(self):
+        class Linear(to.Tree, to.Compact, to.Immutable):
+            w: np.ndarray = Parameter.node()
+
+            def __init__(self, din, dout, name="linear"):
+                self.din = din
+                self.dout = dout
+                self.name = name
+
+            @to.compact
+            def __call__(self):
+                w = self.get_field(
+                    "w", lambda: np.random.uniform(size=(self.din, self.dout))
+                )
+                self()
+
+        tree = Linear(2, 4)
+
+        with pytest.raises(RuntimeError):
+            tree()
+
+    def test_not_compact_in_init(self):
+        a_init_ran = False
+        b_init_ran = False
+
+        class A(to.Tree, to.Immutable):
+            def __init__(self) -> None:
+                nonlocal a_init_ran
+                a_init_ran = True
+                assert not to.in_compact()
+
+        class B(to.Tree, to.Immutable):
+            def __init__(self) -> None:
+                nonlocal b_init_ran
+                b_init_ran = True
+                assert not to.in_compact()
+
+            @to.compact
+            def __call__(self):
+                A()
+
+        b = B()
+
+        assert b_init_ran
+
+        b()
+
+        assert a_init_ran
+        assert "a" in vars(b)
+        assert isinstance(b.a, A)
+
+    def test_with_field_info(self):
+        class Parameter:
+            @staticmethod
+            def fn(x):
+                return np.asarray(x ** 2)
+
+        @dataclass
+        class A(to.Tree, to.Immutable):
+            x: np.ndarray = to.field(node=True, kind=Parameter)
+            y: np.ndarray = to.field(node=True)
+
+        m = A(np.array(2.0), np.array(2.0))
+
+        def field_map_fn(f):
+            return f.kind.fn(f.value)
+
+        m1 = to.map(field_map_fn, m, Parameter, field_info=True)
+
+        assert m.x == 2.0
+        assert m.y == 2.0
+        assert m1.x == 4.0
+        assert m1.y == 2.0
+        assert type(m) == type(m1)
+        assert type(m1.x) == type(m.x)
+        assert type(m1.y) == type(m.y)

--- a/treeo/__init__.py
+++ b/treeo/__init__.py
@@ -6,13 +6,13 @@ from treeo.api import (
     filter,
     merge,
     map,
-    apply,
     to_dict,
     in_compact,
     add_field_info,
     flatten_mode,
     to_string,
     compact,
+    mutable,
 )
 from treeo.mixins import (
     Copy,
@@ -26,8 +26,9 @@ from treeo.mixins import (
     Compact,
     Extensions,
     KindMixin,
+    Immutable,
 )
-from treeo.tree import FlattenMode, FieldInfo, TreeMeta, Tree, copy
+from treeo.tree import FlattenMode, FieldInfo, TreeMeta, Tree, copy, apply
 from treeo.types import FieldMetadata, Nothing, NOTHING, Missing, MISSING, Hashable
 from treeo.utils import OpaquePredicate, ArrayLike, Opaque, field, node, static
 
@@ -43,6 +44,7 @@ __all__ = [
     "Filter",
     "FlattenMode",
     "Hashable",
+    "Immutable",
     "KindMixin",
     "MISSING",
     "Map",
@@ -67,6 +69,7 @@ __all__ = [
     "in_compact",
     "map",
     "merge",
+    "mutable",
     "node",
     "static",
     "to_dict",

--- a/treeo/__init__.py
+++ b/treeo/__init__.py
@@ -27,6 +27,7 @@ from treeo.mixins import (
     Extensions,
     KindMixin,
     Immutable,
+    ImmutableTree,
 )
 from treeo.tree import FlattenMode, FieldInfo, TreeMeta, Tree, copy, apply
 from treeo.types import FieldMetadata, Nothing, NOTHING, Missing, MISSING, Hashable
@@ -45,6 +46,7 @@ __all__ = [
     "FlattenMode",
     "Hashable",
     "Immutable",
+    "ImmutableTree",
     "KindMixin",
     "MISSING",
     "Map",

--- a/treeo/api.py
+++ b/treeo/api.py
@@ -29,6 +29,7 @@ Filter = tp.Union[
     tp.Type[tp.Any],
     tp.Callable[["FieldInfo"], bool],
 ]
+F = tp.TypeVar("F", bound="tp.Callable")
 
 PAD_START = r"__PAD_START__"
 PAD_END = r"__PAD_END__"
@@ -91,10 +92,9 @@ def filter(
         obj = jax.tree_map(apply_filters, obj)
 
     if inplace:
-        input_obj.__dict__.update(obj.__dict__)
-        return input_obj
-    else:
-        return obj
+        obj = utils._safe_update_fields_from(input_obj, obj)
+
+    return obj
 
 
 def merge(
@@ -149,10 +149,9 @@ def merge(
         )
 
     if inplace:
-        input_obj.__dict__.update(obj.__dict__)
-        return input_obj
-    else:
-        return obj
+        obj = utils._safe_update_fields_from(input_obj, obj)
+
+    return obj
 
 
 def map(
@@ -208,50 +207,9 @@ def map(
             new_obj = merge(obj, new_obj)
 
     if inplace:
-        input_obj.__dict__.update(new_obj.__dict__)
-        return input_obj
-    else:
-        return new_obj
+        new_obj = utils._safe_update_fields_from(input_obj, new_obj)
 
-
-def apply(f: tp.Callable[..., None], obj: A, *rest: A, inplace: bool = False) -> A:
-    """
-    Applies a function to all `to.Tree`s in a Pytree. Works very similar to `jax.tree_map`,
-    but its values are `to.Tree`s instead of leaves, also `f` should apply the changes inplace to Tree object.
-
-    If `inplace` is `False`, a copy of the first object is returned with the changes applied.
-    The `rest` of the objects are always copied.
-
-    Arguments:
-        f: The function to apply.
-        obj: a pytree possibly containing Trees.
-        *rest: additional pytrees.
-        inplace: If `True`, the input `obj` is mutated.
-
-    Returns:
-        A new pytree with the updated Trees or the same input `obj` if `inplace` is `True`.
-    """
-    rest = tree_m.copy(rest)
-
-    if not inplace:
-        obj = tree_m.copy(obj)
-
-    objs = (obj,) + rest
-
-    def nested_fn(obj, *rest):
-        if isinstance(obj, Tree):
-            apply(f, obj, *rest, inplace=True)
-
-    jax.tree_map(
-        nested_fn,
-        *objs,
-        is_leaf=lambda x: isinstance(x, Tree) and not x in objs,
-    )
-
-    if isinstance(obj, Tree):
-        f(obj, *rest)
-
-    return obj
+    return new_obj
 
 
 def to_dict(
@@ -268,17 +226,17 @@ def to_dict(
             flat, treedef = jax.tree_flatten(obj)
 
         obj = jax.tree_unflatten(treedef, flat)
-        obj = apply(_remove_field_info_from_metadata, obj)
+        obj = tree_m.apply(_remove_field_info_from_metadata, obj)
 
     return _to_dict(obj, private_fields, static_fields, type_info)
 
 
 def _remove_field_info_from_metadata(obj: Tree):
-
-    obj._field_metadata = jax.tree_map(
-        lambda x: x.value if isinstance(x, FieldInfo) else x,
-        obj._field_metadata,
-    )
+    with tree_m._make_mutable_single(obj):
+        obj._field_metadata = jax.tree_map(
+            lambda x: x.value if isinstance(x, FieldInfo) else x,
+            obj._field_metadata,
+        )
 
 
 def _to_dict(
@@ -520,6 +478,45 @@ def compact(f):
             return f(tree, *args, **kwargs)
 
     wrapper._treeo_compact = True
+
+    return wrapper
+
+
+TA = tp.TypeVar("TA", contravariant=True)
+TB = tp.TypeVar("TB", covariant=True)
+
+
+class _TreeCallable(tp.Protocol, tp.Generic[TA, TB]):
+    """
+    A protocol for tree callables.
+    """
+
+    def __call__(self, _a: TA, *_args, **_kwargs) -> TB:
+        ...
+
+
+class _MutableTreeCallable(tp.Protocol, tp.Generic[A, TB]):
+    """
+    A protocol for tree callables.
+    """
+
+    def __call__(self, _a: A, *_args, **_kwargs) -> tp.Tuple[TB, A]:
+        ...
+
+
+def mutable(f: tp.Callable[..., A]) -> tp.Callable[..., tp.Tuple[A, tp.Any]]:
+    """
+    A decorator that makes a Tree mutable.
+    """
+
+    @functools.wraps(f)
+    def wrapper(tree, *args, **kwargs) -> tp.Tuple[A, tp.Any]:
+        tree = tree_m.copy(tree)
+
+        with tree_m._make_mutable(tree):
+            output = f(tree, *args, **kwargs)
+
+        return output, tree
 
     return wrapper
 

--- a/treeo/mixins.py
+++ b/treeo/mixins.py
@@ -370,7 +370,7 @@ class KindMixin:
 class Immutable:
     """
     Mixin that makes a class immutable. It adds a `.replace()` and `.mutable()` methods to the class
-    which let you modify the state by creating a new one.
+    which let you modify the state by creating a new objects.
     """
 
     _mutable: bool
@@ -379,6 +379,25 @@ class Immutable:
         """
         Returns a copy of the Tree with the given fields specified in `kwargs`
         updated to the new values.
+
+        Example:
+
+        ```python
+        @dataclass
+        class MyTree(to.Tree, to.Immutable):
+            x: int = to.node()
+
+        tree = MyTree(x=1)
+
+        # increment x by 1
+        tree = tree.replace(x=tree.x + 1)
+        ```
+
+        Arguments:
+            **kwargs: The fields to update.
+
+        Returns:
+            A new Tree with the updated fields.
         """
         tree = tree_m.copy(self)
 
@@ -399,6 +418,25 @@ class Immutable:
         an immutable fashion. `mutable` will let you perform stateful operations
         but all update will be performed other a new instance which is returned
         as the second output.
+
+        Example:
+
+        ```python
+        @dataclass
+        class MyTree(to.Tree, to.Immutable):
+            total: int = to.node()
+
+            def accumulate(self, inc) -> None:
+                self.total += inc
+                return self.total
+
+        tree0 = MyTree(total=1)
+
+        # increment by 10
+        total, tree = tree.mutable(10, method="accumulate")
+
+        assert total == 11
+        ```
 
         Arguments:
             *args: The positional arguments to pass to the method.

--- a/treeo/mixins.py
+++ b/treeo/mixins.py
@@ -382,7 +382,7 @@ class Immutable:
 
     #     super().__setattr__(key, value)
 
-    def mutable_call(
+    def mutable(
         self: A,
         *args,
         method: tp.Union[str, tp.Callable] = "__call__",

--- a/treeo/mixins.py
+++ b/treeo/mixins.py
@@ -425,7 +425,7 @@ class Immutable:
         return tree
 
 
-# set __setattr__ outside of class so linters still detect it unknown attribute assignments
+# define __setattr__ outside of class so linters still detect it unknown attribute assignments
 def _immutable_setattr(self: Immutable, key: str, value: tp.Any) -> None:
     if not self._mutable:
         raise RuntimeError(
@@ -436,3 +436,7 @@ def _immutable_setattr(self: Immutable, key: str, value: tp.Any) -> None:
 
 
 Immutable.__setattr__ = _immutable_setattr
+
+
+class ImmutableTree(tree_m.Tree, Immutable):
+    pass

--- a/treeo/utils.py
+++ b/treeo/utils.py
@@ -218,3 +218,9 @@ def _get_name(obj) -> str:
         return _lower_snake_case(obj.__class__.__name__)
     else:
         raise ValueError(f"Could not get name for: {obj}")
+
+
+def _safe_update_fields_from(obj, updates):
+    for field, value in updates.__dict__.items():
+        setattr(obj, field, value)
+    return obj


### PR DESCRIPTION
# Changes
* Adds an `Immutable` mixin that can make `Tree`s effectively immutable (as far as python permits).
* Immutable contains the `.replace` and `.mutable` methods that let you manipulate state in a functionally pure fashion.
* Adds the `mutable` function transformation / decorator which lets you turn function that perform mutable operation into pure functions.