### PR TITLE
Bug Fixes from 0.0.11

### DIFF
--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,40 @@
+import typing as tp
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import treeo as to
+
+
+class TestMixins:
+    def test_apply(self):
+        @dataclass
+        class SomeTree(to.Tree, to.Apply):
+            x: int = to.node()
+
+        tree = SomeTree(x=1)
+
+        def f(tree: SomeTree):
+            tree.x = 2
+
+        tree2 = tree.apply(f)
+
+        assert tree.x == 1
+        assert tree2.x == 2
+
+    def test_apply_inplace(self):
+        @dataclass
+        class SomeTree(to.Tree, to.Apply):
+            x: int = to.node()
+
+        tree = SomeTree(x=1)
+
+        def f(tree: SomeTree):
+            tree.x = 2
+
+        tree.apply(f, inplace=True)
+
+        assert tree.x == 2

--- a/treeo/mixins.py
+++ b/treeo/mixins.py
@@ -219,7 +219,7 @@ class Apply:
         Returns:
             A new pytree with the updated Trees or the same input `obj` if `inplace` is `True`.
         """
-        return api.apply(f, self, *rest, inplace=inplace)
+        return tree_m.apply(f, self, *rest, inplace=inplace)
 
 
 class Compact:


### PR DESCRIPTION
# Changes
*  Fixes an issues that disabled mutability inside `__init__` for `Immutable` classes when `TreeMeta`'s `constructor method is overloaded.
* Fixes the `Apply.apply` mixin method.

Closes cgarciae/treex#68